### PR TITLE
[FIF-133] Realign Authentication Modal Labels & Buttons

### DIFF
--- a/client/src/components/LoginForm.tsx
+++ b/client/src/components/LoginForm.tsx
@@ -3,6 +3,7 @@ import { ErrorResponse, LoginRequest, LoginRequestSchema } from 'baobab-common';
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import axios from 'axios';
+import styles from '../../styles/Form.module.css';
 
 type LoginFormProps = {
   /**
@@ -40,7 +41,11 @@ function LoginForm({ onSuccess }: LoginFormProps): JSX.Element {
   };
 
   return (
-    <Form onFinish={handleSubmit(onSubmit)}>
+    <Form
+      onFinish={handleSubmit(onSubmit)}
+      labelCol={{ span: 4 }}
+      wrapperCol={{ span: 20 }}
+    >
       <Form.Item
         label="Email"
         name="email"
@@ -59,8 +64,8 @@ function LoginForm({ onSuccess }: LoginFormProps): JSX.Element {
         <Input.Password {...register('password')} />
       </Form.Item>
 
-      <Form.Item>
-        <Button type="primary" htmlType="submit" loading={isSubmitting}>
+      <Form.Item className={styles.submit} wrapperCol={{ offset: 19, span: 5 }}>
+        <Button type="primary" htmlType="submit" loading={isSubmitting} block>
           Login
         </Button>
       </Form.Item>

--- a/client/src/components/RegisterForm.tsx
+++ b/client/src/components/RegisterForm.tsx
@@ -7,6 +7,7 @@ import {
 import { useForm } from 'react-hook-form';
 import { yupResolver } from '@hookform/resolvers/yup';
 import axios from 'axios';
+import styles from '../../styles/Form.module.css';
 
 type RegisterFormProps = {
   /**
@@ -48,7 +49,11 @@ function RegisterForm({ onSuccess }: RegisterFormProps): JSX.Element {
   };
 
   return (
-    <Form onFinish={handleSubmit(onSubmit)}>
+    <Form
+      onFinish={handleSubmit(onSubmit)}
+      labelCol={{ span: 4 }}
+      wrapperCol={{ span: 20 }}
+    >
       <Form.Item
         label="First Name"
         name="firstName"
@@ -85,8 +90,8 @@ function RegisterForm({ onSuccess }: RegisterFormProps): JSX.Element {
         <Input.Password {...register('password')} />
       </Form.Item>
 
-      <Form.Item>
-        <Button type="primary" htmlType="submit" loading={isSubmitting}>
+      <Form.Item className={styles.submit} wrapperCol={{ offset: 19, span: 5 }}>
+        <Button type="primary" htmlType="submit" loading={isSubmitting} block>
           Register
         </Button>
       </Form.Item>

--- a/client/styles/Form.module.css
+++ b/client/styles/Form.module.css
@@ -1,0 +1,3 @@
+.submit {
+    margin-bottom: 0;
+}


### PR DESCRIPTION
## [FIF-133] Equally Align Authentication Modal Labels & Buttons
Fixes: This PR addresses a sprint 4 feedback to align all labels in the authenication modals to take up equal space and to right align the "confirmation" buttons as convention adherence.

-   [x] Has the code been formatted?
-   [ ] Have dependencies/packages been added?

### Testing
-   [x] Does the code have sufficient automated test coverage? If not, include a reasoning and steps required to manually QA

Open the registration & login modals via the top right buttons to examine the changes.